### PR TITLE
Use notifications, standard naming/better parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 A couple scripts to enable Beat Saber OneClick install functionality on Linux. Currently supports OneClick install of songs and sabers.
 
 ## Dependencies
-Requires `zenity` (for GUI), `wget` (for downloading stuff), `unzip`, and bash.
+Requires `zenity` (for GUI), `wget` (for downloading stuff), `unzip`, `jq` for info parsing, and bash.
 
 ## How do I use this?
 	git clone https://github.com/YungDaVinci/beatsaber-oneclick-linux

--- a/bs-oneclick-install.sh
+++ b/bs-oneclick-install.sh
@@ -1,20 +1,21 @@
 #!/bin/bash
 # installs the scripts and what not
 #set -x
-cp bs-oneclick-temp bs-oneclick.sh
-cp playlist-installer-temp playlist-installer
-cp bs-oneclick-desktop-temp bs-oneclick.desktop
-
-mkdir -p ~/.local/share/applications
-xdg-mime default bs-oneclick.desktop x-scheme-handler/beatsaver x-scheme-handler/modelsaber x-scheme-handler/bsplaylist
+set -e
 
 bs_install="$HOME/.local/share/Steam/steamapps/common/Beat Saber"
 
-zenity --info --title="OneClick Installer" --text="Please navigate to your Beat Saber install directory to properly set up the OneClick Installer." --width=500
+zenity --info --title="OneClick Installer" --text="Please navigate to your Beat Saber install directory to properly set up the OneClick Installer."
 
 while : ; do
-	bs_install=$( zenity --file-selection --directory --title="Please navigate to your Beat Saber install directory." )
+	bs_install=$( zenity --file-selection --directory --title="Please navigate to your Beat Saber install directory." --filename="$HOME/.local/share/Steam/steamapps/common/Beat Saber")
 	if [[ -f "$bs_install/Beat Saber.exe" ]]; then 
+		cp bs-oneclick-temp bs-oneclick.sh
+		cp playlist-installer-temp playlist-installer
+		cp bs-oneclick-desktop-temp bs-oneclick.desktop
+
+		mkdir -p ~/.local/share/applications
+		xdg-mime default bs-oneclick.desktop x-scheme-handler/beatsaver x-scheme-handler/modelsaber x-scheme-handler/bsplaylist
 		# welcome to slash hell
 		bs_install_sed=$( echo $bs_install | sed 's,/,\\/,g' )
 		sed -i "s,bs_install=.*,bs_install=\"$bs_install_sed\"," bs-oneclick.sh
@@ -26,5 +27,5 @@ while : ; do
 		break
 	fi
 	
-	zenity --error --title="OneClick Installer" --text="Beat Saber installation not detected in that folder. Try again." --width=500
+	zenity --error --title="OneClick Installer" --text="Beat Saber installation not detected in that folder. Try again."
 done

--- a/bs-oneclick-temp
+++ b/bs-oneclick-temp
@@ -1,5 +1,7 @@
 #!/bin/bash
 #set -x
+set -e
+
 bs_install=
 cd "$( echo "$bs_install" | tr -d '\r' )"
 
@@ -14,15 +16,13 @@ if [[ $uri == "beatsaver" ]]; then
 	
 	# check if song already installed first
 	if [[ $( ls | grep $key ) ]]; then
-		zenity --error --title="OneClick Installer" --text="You already have this song installed!"
+		zenity --notification --window-icon="error" --title="OneClick Installer" --text="You already have this song installed!"
 		exit 1
 	fi
 	
 	dir=$key"-dir"
 	(
-
 		# make directory
-		
 		mkdir $dir
 		cd $dir
 		
@@ -33,15 +33,14 @@ if [[ $uri == "beatsaver" ]]; then
 
 	) | zenity --progress --pulsate --auto-close --no-cancel \
 		--text="Installing song..." --title="OneClick Installer"
-		
+
 	# rename directory
 	info=$( ls $dir | grep -i info ) # case insensitive!
- 	songname=$( grep "_songName" $dir/$info \
-				| tr -d "[:space:]" \
-				| sed -e 's/^\"_songName\"\:\"//' -e 's/\",$//')
-	mv $dir "$songname ($key)"
+	songname=$( jq -r "._songName" $dir/$info )
+	author=$( jq -r "._levelAuthorName" $dir/$info )
+	mv $dir "$key ($songname - $author)"
 
-	zenity --info --text="$( echo $songname | sed 's/\&/\&amp;/' ) installed." --title="OneClick Installer" --width=300 --icon-name="checkbox-checked"
+	zenity --notification --window-icon="info" --text="$( echo $songname | sed 's/\&/\&amp;/' ) installed." --title="OneClick Installer"
 
 # oneclick saber
 elif [[ $uri == "modelsaber" ]]; then
@@ -51,28 +50,28 @@ elif [[ $uri == "modelsaber" ]]; then
 		# make sure Custom Sabers is installed
 		if ! [[ -d "CustomSabers" ]]; then
 			zenity --error --title="OneClick Installer" \
-			 --text="You don't have the CustomSabers mod installed! You can install it with <span background='gray' foreground='black' font_family='monospace' allow_breaks='false'>./QBeat --install CustomSabers</span>. Visit <a href='https://github.com/geefr/beatsaber-linux-goodies/tree/master/QBeat'>https://github.com/geefr/beatsaber-linux-goodies/tree/master/QBeat</a> if you need QBeat." --width=500
-			 exit 1
+				--text="You don't have the CustomSabers mod installed! You can install it with <span background='gray' foreground='black' font_family='monospace' allow_breaks='false'>./QBeat --install CustomSabers</span>. Visit <a href='https://github.com/geefr/beatsaber-linux-goodies/tree/master/QBeat'>https://github.com/geefr/beatsaber-linux-goodies/tree/master/QBeat</a> if you need QBeat." --width=500
+			exit 1
 		fi
 		
 		# install saber
 		key=$( echo $1 | sed 's/modelsaber:\/\/saber\///' )
 		
 		(
-		cd "CustomSabers"
-		wget -q "https://modelsaber.com/files/saber/$key" 
+			cd "CustomSabers"
+			wget -q "https://modelsaber.com/files/saber/$key"
 		) | zenity --progress --pulsate --auto-close --no-cancel \
 		--text="Installing saber..." --title="OneClick Installer"
 		
 		sabername=$( echo $key | sed -e 's/[0-9]*\///' -e 's/.saber//' )
-		zenity --info --text="$( echo $sabername| sed 's/\&/\&amp;/' ) installed." --title="OneClick Installer" --width=300 --icon-name="checkbox-checked"
+		zenity --notification --window-icon="info" --text="$( echo $sabername| sed 's/\&/\&amp;/' ) installed." --title="OneClick Installer" --width=300 --icon-name="checkbox-checked"
 		
 	elif [[ $thing == "/platform/" ]]; then
 		
 		if ! [[ -d "CustomPlatforms" ]]; then
-			zenity --error --title="OneClick Installer" \
-			 --text="You don't have the CustomPlatforms mod installed! Check out the BSMG discord to get it." --width=500
-			 exit 1
+			zenity --notification --window-icon="error" --title="OneClick Installer" \
+			--text="You don't have the CustomPlatforms mod installed! Check out the BSMG discord to get it." --width=500
+			exit 1
 		fi
 		
 		# install platform
@@ -80,13 +79,13 @@ elif [[ $uri == "modelsaber" ]]; then
 		
 		
 		(
-		cd "CustomPlatforms"
-		wget -q "https://modelsaber.com/files/platform/$key" 
+			cd "CustomPlatforms"
+			wget -q "https://modelsaber.com/files/platform/$key"
 		) | zenity --progress --pulsate --auto-close --no-cancel \
-		--text="Installing platform..." --title="OneClick Installer"
+			--text="Installing platform..." --title="OneClick Installer"
 		
 		platformname=$( echo $key | sed -e 's/[0-9]*\///' -e 's/.plat//' )
-		zenity --info --text="$( echo $platformname| sed 's/\&/\&amp;/' ) installed." --title="OneClick Installer" --width=300 --icon-name="checkbox-checked"
+		zenity --notification --window-icon="info" --text="$( echo $platformname| sed 's/\&/\&amp;/' ) installed." --title="OneClick Installer" --width=300 --icon-name="checkbox-checked"
 	fi
 
 # oneclick playlists
@@ -97,7 +96,7 @@ elif [[ $uri == "bsplaylist" ]]; then
 	cd Playlists
 	
 	if [[ $( ls | grep $pname ) ]]; then
-		zenity --error --title="OneClick Installer" --text="You already have this playlist installed!"
+		zenity --notification --window-icon="error" --title="OneClick Installer" --text="You already have this playlist installed!"
 		exit 1
 	fi
 	

--- a/playlist-installer-temp
+++ b/playlist-installer-temp
@@ -33,10 +33,9 @@ while IFS='},' read -ra songs ; do
 				cd ..
 				# rename directory
 				info=$( ls $dir | grep -i info ) # case insensitive!
-		 		songname=$( grep "_songName" $dir/$info \
-						| tr -d "[:space:]" \
-						| sed -e 's/^\"_songName\"\:\"//' -e 's/\",$//')
-				mv $dir "$songname ($key)"
+				songname=$( jq -r "._songName" $dir/$info )
+				author=$( jq -r "._levelAuthorName" $dir/$info )
+				mv $dir "$key ($songname - $author)"
 			fi
 			
 		fi
@@ -45,5 +44,4 @@ done <<< $songlist
 ) | zenity --progress --pulsate --auto-close --no-cancel \
 		--text="Installing $( echo $pltitle | sed 's/\&/\&amp;/' )..." --title="Playlist Installer" --width=300
 
-zenity --info --text="$( echo $pltitle | sed 's/\&/\&amp;/' ) installed." --title="Playlist Installer" --width=300 --icon-name="checkbox-checked"
-
+zenity --notification --window-icon="info" --text="$( echo $pltitle | sed 's/\&/\&amp;/' ) installed." --title="Playlist Installer" 


### PR DESCRIPTION
Basically what the title says: uses notifications so that it requires less user interaction, make the song folders match what ModAssistant names them (and preserving spaces), and exiting on error as to not mess stuff up (eg `cd` failing and putting files in random directories)