### PR TITLE
Fixes

### DIFF
--- a/bs-oneclick-install.py
+++ b/bs-oneclick-install.py
@@ -52,7 +52,7 @@ NoDisplay=true
         shutil.move(src=pathlib.Path.cwd()/'bs-oneclick.desktop', dst=full_path)
 
         # set default mime type
-        subprocess.run(['xdg-mime','default', full_path,
+        subprocess.run(['xdg-mime','default', 'bs-oneclick.desktop',
             'x-scheme-handler/beatsaver','x-scheme-handler/modelsaber','x-scheme-handler/bsplaylist'])
 
         GLib.idle_add(label.set_text, "Beat Saber OneClick has been installed. Enjoy!")

--- a/bs-oneclick.py
+++ b/bs-oneclick.py
@@ -223,7 +223,7 @@ if __name__ == "__main__":
 
     bs_install = None
     try:
-        with open("bs-path.txt") as file:
+        with open(script_path/"bs-path.txt") as file:
             bs_install = pathlib.Path(file.readline())
     except FileNotFoundError: # missing bs-path.txt
         invalid_path_error()


### PR DESCRIPTION
The application supplied to `xdg-mime` should be the desktop file basename only. It might work on some DEs, but not with `xdg-open`'s generic fallback or with Firefox.

Also include the full path for`bs-path.txt`, because for some reason Firefox messes with the working directory.